### PR TITLE
Convert packaged jars to OSGi bundles

### DIFF
--- a/throwing-interfaces/pom.xml
+++ b/throwing-interfaces/pom.xml
@@ -7,6 +7,7 @@
   </parent>
   <artifactId>throwing-interfaces</artifactId>
   <version>1.1.3-SNAPSHOT</version>
+  <packaging>bundle</packaging>
   <url>${github.url}</url>
   <scm>
     <connection>scm:git:${github.url}.git</connection>
@@ -28,4 +29,14 @@
       <artifactId>mockito-all</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.5.1</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/throwing-stream/pom.xml
+++ b/throwing-stream/pom.xml
@@ -6,6 +6,7 @@
     <version>3.1.2-SNAPSHOT</version>
   </parent>
   <artifactId>throwing-streams</artifactId>
+  <packaging>bundle</packaging>
   <dependencies>
     <dependency>
       <groupId>name.falgout.jeffrey</groupId>
@@ -25,4 +26,14 @@
       <artifactId>mockito-all</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.5.1</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Use maven-bundle-plugin to add appropriate OSGi headers to jars, thus
turning them into OSGi bundles.

I would also ask you kindly to deploy a release (3.2.0 ?) on maven central with these OSGi bundle headers, which would make integration into such projects easier for everyone.

Thank you